### PR TITLE
Fix some formatting glitches

### DIFF
--- a/iso4217/Classes/CurrencyCode+Extensions.swift
+++ b/iso4217/Classes/CurrencyCode+Extensions.swift
@@ -39,7 +39,17 @@ private extension CurrencyCode {
     var priceFormatter: NumberFormatter {
         return memoizedFormatters.memoize(self) {
             let formatter = NumberFormatter()
-            formatter.numberStyle = .currency
+            
+            /*
+             
+             This fixes a bug with USD where using the first locale in the list of locales that use USD comes up with the Equador Locale.
+             So instead of grabbing a random locale I just changed the formatter to use the rawValue of the current type.
+             I'm using this library in a budgeting app and this fixed the bugs I was having.
+             
+             */
+//            formatter.numberStyle = .currency
+            formatter.currencyCode = self.rawValue
+            
             formatter.locale = self.priceLocale
 
             return formatter


### PR DESCRIPTION
I found a bug when using the USD and a few other values where the locale chosen for them is Equador or a different country that uses USD, but I would assume USD is mostly going to be used in the US. This line fixed that problem for me.